### PR TITLE
Modify the self-referencing Parsed struct to use the ouroboros crate.

### DIFF
--- a/askama_parser/Cargo.toml
+++ b/askama_parser/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = "1.65"
 
 [dependencies]
 nom = { version = "7", default-features = false, features = ["alloc"] }
+ouroboros = "0.18.5"
 
 [dev-dependencies]
 criterion = "0.5"


### PR DESCRIPTION
I came across this self referential struct while looking at the use of the unsafe keyword in various rust crates. In part I was trying to search for candidates to work on related to Google's Patch Rewards program.
The custom-built self-referencing that this PR replaces is a relatively straight-forward and easy to understand use of unsafe rust, but I think an argument can be made that it is better to refactor it to use ouroboros. It reduces the surface area of unsafe rust in askama.

Do you think this is worthwhile, or do you dislike such a change for other reasons? (Such as the added dependency perhaps.)

This change passses the existing testsuite, but I noticed that this code path is not covered very well. If this refactoring seems reasonable for askama, then perhaps I should add a number of testcases for this part of the codebase? 

PS:
I doubt that this change will qualify for Patch Rewards program, but it seemed like an easy and useful fix to do anyway. How do you look towards removing the remaining uses of unsafe rust as well? All of them are relate to `from_utf8_unchecked`, which I think is even less of a issue, so I'm not sure if that is worth it. Although I noticed that some of those conversions rely on serde_json's behavior of never outputting non-utf8. Which it never does, but as far as I know that is not given as an external guarantee by serde_json, and the JSON spec weirdly actually allows non-utf8 for non-internet use. I have no idea yet how to refactor that code by the way, it may be hard to do while keeping the performance.